### PR TITLE
Calendars Shell presented (task #3874)

### DIFF
--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -119,8 +119,11 @@ class CalendarEventsTable extends Table
 
         $conditions['calendar_id'] = $calendar->id;
 
-        if (!empty($options['period'])) {
+        if (!empty($options['period']['start_date'])) {
             $conditions['start_date >='] = $options['period']['start_date'];
+        }
+
+        if (!empty($options['period']['end_date'])) {
             $conditions['end_date <='] = $options['period']['end_date'];
         }
 

--- a/src/Shell/CalendarsShell.php
+++ b/src/Shell/CalendarsShell.php
@@ -1,0 +1,38 @@
+<?php
+namespace Qobo\Calendar\Shell;
+
+use Cake\Console\ConsoleOptionParser;
+use Cake\Console\Shell;
+
+/**
+ * SyncCalendars shell command.
+ */
+class CalendarsShell extends Shell
+{
+
+    public $tasks = [
+        'Qobo/Calendar.Sync',
+    ];
+
+    /**
+     * Manage the available sub-commands along with their arguments and help
+     *
+     * @see http://book.cakephp.org/3.0/en/console-and-shells.html#configuring-options-and-generating-help
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $parser = new ConsoleOptionParser('console');
+
+        $parser->description(
+            'Calendars Shell helps you import and fetch calendars & ' .
+            'events from cakephp-calendars plugin'
+        )->addSubCommand('sync', [
+            'help' => __('Synchronize calendars with the plugin'),
+            'parser' => $this->Sync->getOptionParser(),
+        ]);
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/SyncTask.php
+++ b/src/Shell/Task/SyncTask.php
@@ -1,0 +1,90 @@
+<?php
+namespace Qobo\Calendar\Shell\Task;
+
+use Cake\Console\Shell;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Sync shell task.
+ */
+class SyncTask extends Shell
+{
+
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser->setDescription(
+            __('Synchronize local and remote calendars with the database')
+        );
+
+        $parser->addOption('start', [
+            'description' => __('Specify start interval for the events to fetch'),
+            'help' => __("Start date 'YYYY-MM-DD HH:MM:SS' for events to fetch"),
+        ]);
+
+        $parser->addOption('end', [
+            'description' => __('Specify end interval for the events to fetch'),
+            'help' => __("End date 'YYYY-MM-DD HH:MM:SS' for events to fetch"),
+        ]);
+
+        return $parser;
+    }
+
+
+    /**
+     * main() method.
+     *
+     * @return bool|int|null Success or error code.
+     */
+    public function main()
+    {
+        $calendarsProcessed = 1;
+        $output = [];
+
+        $progress = $this->helper('Progress');
+        $progress->init();
+
+        $this->info('Preparing for calendar sync...');
+
+        $result = $options = [];
+        $table = TableRegistry::get('Qobo/Calendar.Calendars');
+
+        if (!empty($this->params['start'])) {
+            $options['period']['start_date'] = $this->params['start'];
+        }
+
+        if (!empty($this->params['end'])) {
+            $options['period']['end_date'] = $this->params['end'];
+        }
+
+        $result['calendars'] = $table->syncCalendars($options);
+
+        if (empty($result['calendars'])) {
+            $this->abort('No calendars found for synchronization');
+        }
+
+        foreach ($result['calendars'] as $actionName => $calendars) {
+            foreach ($calendars as $k => $calendar) {
+                $resultEvents = $table->syncCalendarEvents($calendar, $options);
+
+                $output[] = [
+                    'action' => $actionName,
+                    'calendar' => $calendar,
+                    'events' => $resultEvents
+                ];
+
+                $progress->increment(100 / ++$calendarsProcessed);
+                $progress->draw();
+            }
+        }
+
+        $this->out(null);
+        $this->out('<success>Synchronization complete!</success>');
+
+        if (true == $this->params['verbose']) {
+            print_r($output);
+        }
+
+        return $output;
+    }
+}

--- a/src/Shell/Task/SyncTask.php
+++ b/src/Shell/Task/SyncTask.php
@@ -10,6 +10,11 @@ use Cake\ORM\TableRegistry;
 class SyncTask extends Shell
 {
 
+    /**
+     * Manage available options via Parser
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
@@ -29,7 +34,6 @@ class SyncTask extends Shell
 
         return $parser;
     }
-
 
     /**
      * main() method.


### PR DESCRIPTION
To automate synchronization of calendars and events - Calendars Shell was added to the plugin.

Sync Task allows specifying `start` and `end` options to limit the time intervals for events being synchronized for the corresponding calendars.

CalendarEvents `period` array is not optional, you can specify no/one/both time intervals to cut down the events result set.

```php
./bin/cake calendars sync -h
```
Help message will guide you through the list of available arguments for the command.
