### PR TITLE
Adding Calendar Templates from config (task #3875)

### DIFF
--- a/config/Migrations/20170619123256_AddTemplatesToCalendars.php
+++ b/config/Migrations/20170619123256_AddTemplatesToCalendars.php
@@ -1,0 +1,24 @@
+<?php
+use Migrations\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class AddTemplatesToCalendars extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('calendars');
+        $table->addColumn('templates', 'text', [
+            'default' => null,
+            'limit' => MysqlAdapter::TEXT_LONG,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,8 +4,7 @@ use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Qobo\Calendar\Events\GetCalendarsListener;
 
-$config = Configure::read('Calendar.Types');
-
+$config = Configure::read('Calendar');
 if (empty($config)) {
     Configure::load('Qobo/Calendar.calendar', 'default');
 }

--- a/config/calendar.php
+++ b/config/calendar.php
@@ -36,5 +36,32 @@ return [
                 ],
             ],
         ],
-    ]
+        'Templates' => [
+            'calls' => [
+                'name' => 'Calls',
+                'value' => 'calls',
+                'minDuration' => '30 minutes',
+            ],
+            'meetings' => [
+                'name' => 'Meetings',
+                'value' => 'meetings',
+                'minDuration' => '1 hour',
+            ],
+            'tasks' => [
+                'name' => 'Tasks',
+                'value' => 'tasks',
+                'minDuration' => '1 hour',
+            ],
+            'annual_leaves' => [
+                'name' => 'Annual Leaves',
+                'value' => 'annual_leaves',
+                'minDuration' => '1 day',
+            ],
+            'birthdays' => [
+                'name' => 'Birthday',
+                'value' => 'birthdays',
+                'minDuration' => '1 day',
+            ],
+        ],
+    ],
 ];

--- a/config/calendar.php
+++ b/config/calendar.php
@@ -37,6 +37,11 @@ return [
             ],
         ],
         'Templates' => [
+            '_default' => [
+                'name' => 'Default Template',
+                'value' => '_default',
+                'minDuration' => '30 minutes',
+            ],
             'calls' => [
                 'name' => 'Calls',
                 'value' => 'calls',

--- a/src/Controller/CalendarsController.php
+++ b/src/Controller/CalendarsController.php
@@ -72,32 +72,16 @@ class CalendarsController extends AppController
      */
     public function add()
     {
-        $templatesConfig = Configure::read('Calendar.Templates');
-        $templates = [];
-
-        foreach ($templatesConfig as $k => $item) {
-            $templates[$item['value']] = $item['name'];
-        }
+        $templates = $this->Calendars->getCalendarTemplatesFieldList();
 
         $calendar = $this->Calendars->newEntity();
+
         if ($this->request->is('post')) {
             $data = $this->request->getData();
 
-            if (empty($data['templates'])) {
-                $data['templates'] = array_merge($data['templates'], ['_default' => $templatesConfig['_default']]);
-            } else {
-                $templateChoices = [];
-                foreach ($templatesConfig as $k => $template) {
-                    if (in_array($template['value'], array_values($data['templates']))) {
-                        $templateChoices[$template['value']] = $template;
-                    }
-                }
-                if (!empty($templateChoices)) {
-                    $data['templates'] = $templateChoices;
-                }
-            }
+            $currentTemplates = $this->Calendars->setCalendarTemplatesField($data);
 
-            $data['templates'] = json_encode($data['templates']);
+            $data['templates'] = $currentTemplates;
             $calendar = $this->Calendars->patchEntity($calendar, $data);
 
             if ($this->Calendars->save($calendar)) {
@@ -121,44 +105,21 @@ class CalendarsController extends AppController
      */
     public function edit($id = null)
     {
-        $templatesConfig = Configure::read('Calendar.Templates');
-        $templates = $currentTemplates = [];
-
-        foreach ($templatesConfig as $k => $item) {
-            $templates[$item['value']] = $item['name'];
-        }
+        $templates = $this->Calendars->getCalendarTemplatesFieldList();
 
         $calendar = $this->Calendars->get($id, [
             'contain' => []
         ]);
 
-        if (!empty($calendar->templates)) {
-            $currentTemplates = json_decode($calendar->templates, true);
-            $tmp = [];
-            foreach ($currentTemplates as $k => $template) {
-                $tmp[] = $template['value'];
-            }
-
-            $calendar->templates = $tmp;
-        }
+        $currentTemplates = $this->Calendars->getCalendarTemplatesField($calendar);
+        $calendar->templates = $currentTemplates;
 
         if ($this->request->is(['patch', 'post', 'put'])) {
             $data = $this->request->getData();
 
-            if (empty($data['templates'])) {
-                $data['templates'] = ['_default' => $templatesConfig['_default']];
-            } else {
-                $templateChoices = [];
-                foreach ($templatesConfig as $k => $template) {
-                    if (in_array($template['value'], array_values($data['templates']))) {
-                        $templateChoices[$template['value']] = $template;
-                    }
-                }
-                if (!empty($templateChoices)) {
-                    $data['templates'] = $templateChoices;
-                }
-            }
-            $data['templates'] = json_encode($data['templates']);
+            $currentTemplates = $this->Calendars->setCalendarTemplatesField($data);
+
+            $data['templates'] = $currentTemplates;
             $calendar = $this->Calendars->patchEntity($calendar, $data);
 
             if ($this->Calendars->save($calendar)) {

--- a/src/Model/Table/CalendarsTable.php
+++ b/src/Model/Table/CalendarsTable.php
@@ -158,6 +158,81 @@ class CalendarsTable extends Table
     }
 
     /**
+     * Get Calendar Template Fields list
+     *
+     * @return array $result with key/value pairs of templates.
+     */
+    public function getCalendarTemplatesFieldList()
+    {
+        $result = [];
+        $templatesConfig = Configure::read('Calendar.Templates');
+
+        if (empty($templatesConfig)) {
+            return $result;
+        }
+
+        foreach ($templatesConfig as $k => $template) {
+            $result[$template['value']] = $template['name'];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get Calendar Template Field data
+     *
+     * @param \Cake\Model\Entity $entity of the calendar
+     *
+     * @return array $result of the fields.
+     */
+    public function getCalendarTemplatesField($entity = null)
+    {
+        $result = [];
+        $templatesConfig = Configure::read('Calendar.Templates');
+
+        if (empty($entity->templates)) {
+            foreach ($templatesConfig as $k => $template) {
+                $result[$template['value']] = $template['name'];
+            }
+        } else {
+            $templates = json_decode($entity->templates, true);
+
+            foreach ($templates as $k => $template) {
+                if (in_array($template['value'], array_keys($templatesConfig))) {
+                    $result[] = $template['value'];
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Set Calendar Template Field
+     *
+     * @param array $data with templates keys
+     *
+     * @return array $result with JSON configs for template field.
+     */
+    public function setCalendarTemplatesField($data = null)
+    {
+        $result = [];
+        $templatesConfig = Configure::read('Calendar.Templates');
+
+        if (empty($data['templates'])) {
+            $result['_default'] = $templatesConfig['_default'];
+        } else {
+            foreach ($data['templates'] as $templateName) {
+                if (in_array($templateName, array_keys($templatesConfig))) {
+                    $result[$templateName] = $templatesConfig[$templateName];
+                }
+            }
+        }
+
+        return json_encode($result);
+    }
+
+    /**
      * Synchronize calendars
      *
      * @param array $options passed from the outside.

--- a/src/Template/Calendars/add.ctp
+++ b/src/Template/Calendars/add.ctp
@@ -53,19 +53,29 @@ foreach ($icons as $k => $v) {
                     <?= $this->Form->control('source', ['label' => __('Source Name')]); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
+                    <?= $this->Form->input('templates', [
+                        'type' => 'select',
+                        'options' => $templates,
+                        'class' => 'select2',
+                        'empty' => true,
+                        'multiple' => 'multiple',
+                    ]);?>
+
                     <?= $this->Form->input('color', [
                         'type' => 'select',
                         'options' => $colors,
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
-
                     <?= $this->Form->input('icon', [
                         'type' => 'select',
                         'options' => $icons,
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
+
+                </div>
+                <div class="col-xs-12 col-md-6">
                     <?= $this->Form->control('source_id', ['type' => 'text', 'label' => __('Source ID')]);?>
 
                     <?= $this->Form->control('active');?>

--- a/src/Template/Calendars/edit.ctp
+++ b/src/Template/Calendars/edit.ctp
@@ -53,19 +53,29 @@ foreach ($icons as $k => $v) {
                     <?= $this->Form->control('source', ['label' => __('Source Name')]); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
+                    <?= $this->Form->input('templates', [
+                        'type' => 'select',
+                        'options' => $templates,
+                        'class' => 'select2',
+                        'empty' => true,
+                        'multiple' => 'multiple',
+                    ]);?>
+
                     <?= $this->Form->input('color', [
                         'type' => 'select',
                         'options' => $colors,
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
-
                     <?= $this->Form->input('icon', [
                         'type' => 'select',
                         'options' => $icons,
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
+
+                </div>
+                <div class="col-xs-12 col-md-6">
                     <?= $this->Form->control('source_id', ['type' => 'text', 'label' => __('Source ID')]);?>
 
                     <?= $this->Form->control('active');?>

--- a/tests/TestCase/Model/Table/CalendarsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarsTableTest.php
@@ -209,5 +209,10 @@ class CalendarsTableTest extends TestCase
     {
         $result = $this->Calendars->setCalendarTemplatesField();
         $this->assertNotEmpty($result);
+
+        $result = $this->Calendars->setCalendarTemplatesField(['templates' => ['_default', 'meetings']]);
+        $this->assertNotEmpty($result);
+        $result = json_decode($result, true);
+        $this->assertEquals(['_default', 'meetings'], array_keys($result));
     }
 }

--- a/tests/TestCase/Model/Table/CalendarsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarsTableTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Qobo\Calendar\Test\TestCase\Model\Table;
 
+use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Qobo\Calendar\Model\Table\CalendarsTable;
@@ -57,7 +58,7 @@ class CalendarsTableTest extends TestCase
         $result = $this->Calendars->getCalendarTypes();
         $this->assertTrue(is_array($result));
 
-        \Cake\Core\Configure::write('Calendar.Types', ['foo' => ['name' => 'bar', 'value' => 'bar']]);
+        Configure::write('Calendar.Types', ['foo' => ['name' => 'bar', 'value' => 'bar']]);
         $result = $this->Calendars->getCalendarTypes();
         $this->assertEquals(['bar' => 'bar'], $result);
     }
@@ -75,7 +76,7 @@ class CalendarsTableTest extends TestCase
         $this->assertNotEmpty($result);
         $this->assertEquals($result[0]->id, '9390cbc1-dc1d-474a-a372-de92dce85aaa');
 
-        \Cake\Core\Configure::write('Calendar.Types', ['foo' => ['name' => 'bar', 'value' => 'bar']]);
+        Configure::write('Calendar.Types', ['foo' => ['name' => 'bar', 'value' => 'bar']]);
         $result = $this->Calendars->getCalendars(['conditions' => ['id' => '9390cbc1-dc1d-474a-a372-de92dce85aaa']]);
     }
 
@@ -159,5 +160,54 @@ class CalendarsTableTest extends TestCase
         $result = $this->Calendars->getItemDifferences($this->Calendars);
         $this->assertTrue(is_array($result));
         $this->assertEquals($result, ['add' => [], 'update' => [], 'delete' => []]);
+    }
+
+    public function testGetCalendarTemplatesFieldList()
+    {
+        $result = Configure::read('Calendar.Templates');
+        $this->assertNotEmpty($result);
+        $this->assertTrue(is_array($result));
+
+        $templates = $this->Calendars->getCalendarTemplatesFieldList();
+        $this->assertTrue(is_array($templates));
+        $this->assertEquals($templates, ['_default' => 'Default Template', 'calls' => 'Calls', 'meetings' => 'Meetings']);
+    }
+
+    public function testGetCalendarTemplatesFieldListEmpty()
+    {
+        Configure::delete('Calendar.Templates');
+        $result = Configure::read('Calendar.Templates');
+        $this->assertEmpty($result);
+
+        $result = $this->Calendars->getCalendarTemplatesFieldList();
+        $this->assertEquals($result, []);
+    }
+
+    public function testGetCalendarTemplatesField()
+    {
+        $result = $this->Calendars->getCalendarTemplatesField();
+        $this->assertTrue(is_array($result));
+        $this->assertNotEmpty($result);
+
+        $dummyObj = (object)[
+            'id' => 'foobar',
+            'templates' => json_encode([
+                '_default' => [
+                    'name' => 'Default Foo',
+                    'value' => '_default',
+                    'minDuration' => '100 years'
+                ]
+            ])
+        ];
+
+        $result = $this->Calendars->getCalendarTemplatesField($dummyObj);
+        $this->assertNotEmpty($result);
+        $this->assertEquals($result, ['_default']);
+    }
+
+    public function testSetCalendarTemplatesField()
+    {
+        $result = $this->Calendars->setCalendarTemplatesField();
+        $this->assertNotEmpty($result);
     }
 }

--- a/tests/TestCase/Shell/Task/SyncTaskTest.php
+++ b/tests/TestCase/Shell/Task/SyncTaskTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Qobo\Calendar\Test\TestCase\Shell\Task;
+
+use Cake\TestSuite\TestCase;
+use Qobo\Calendar\Shell\Task\SyncTask;
+
+/**
+ * Qobo\Calendar\Shell\Task\SyncTask Test Case
+ */
+class SyncTaskTest extends TestCase
+{
+
+    /**
+     * ConsoleIo mock
+     *
+     * @var \Cake\Console\ConsoleIo|\PHPUnit_Framework_MockObject_MockObject
+     */
+    public $io;
+
+    /**
+     * Test subject
+     *
+     * @var \Qobo\Calendar\Shell\Task\SyncTask
+     */
+    public $Sync;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+
+        $this->Sync = $this->getMockBuilder('Qobo\Calendar\Shell\Task\SyncTask')
+            ->setConstructorArgs([$this->io])
+            ->getMock();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Sync);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test main method
+     *
+     * @return void
+     */
+    public function testMain()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -58,7 +58,7 @@ Configure::write('App', [
 ]);
 Configure::write('debug', true);
 
-$config = Configure::read('Calendar.Types');
+$config = Configure::read('Calendar');
 
 if (empty($config)) {
     Configure::load('calendar', 'default');

--- a/tests/config/calendar.php
+++ b/tests/config/calendar.php
@@ -36,5 +36,22 @@ return [
                 ],
             ],
         ],
-    ]
+        'Templates' => [
+            '_default' => [
+                'name' => 'Default Template',
+                'value' => '_default',
+                'minDuration' => '30 minutes',
+            ],
+            'calls' => [
+                'name' => 'Calls',
+                'value' => 'calls',
+                'minDuration' => '30 minutes',
+            ],
+            'meetings' => [
+                'name' => 'Meetings',
+                'value' => 'meetings',
+                'minDuration' => '1 hour',
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
Calendar Templates store configurations for event types allowed to be stored for within given calendar.

Calendar templates pre-define customization options for events with certain types.
Currently supporting `minDuration` option that shifts `end_date` to given value stored in `config/calendar.php`.