### PR TITLE
Removing automagic fields from the CRUD

### DIFF
--- a/src/Template/CalendarEvents/edit.ctp
+++ b/src/Template/CalendarEvents/edit.ctp
@@ -39,8 +39,6 @@ echo $this->Html->script(
                     <?php
                         echo $this->Form->control('title');
                         echo $this->Form->control('calendar_id', ['options' => $calendars]);
-                        echo $this->Form->control('source_id', ['label' => __('Source ID')]);
-                        echo $this->Form->control('source', ['label' => __('Source Name')]);
                     ?>
                 </div>
                 <div class="col-xs-12 col-md-6">

--- a/src/Template/Calendars/add.ctp
+++ b/src/Template/Calendars/add.ctp
@@ -50,7 +50,6 @@ foreach ($icons as $k => $v) {
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
-                    <?= $this->Form->control('source', ['label' => __('Source Name')]); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
                     <?= $this->Form->input('templates', [
@@ -67,6 +66,8 @@ foreach ($icons as $k => $v) {
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
+                </div>
+                <div class="col-xs-12 col-md-6">
                     <?= $this->Form->input('icon', [
                         'type' => 'select',
                         'options' => $icons,
@@ -74,9 +75,6 @@ foreach ($icons as $k => $v) {
                         'empty' => true
                     ]) ?>
 
-                </div>
-                <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->control('source_id', ['type' => 'text', 'label' => __('Source ID')]);?>
 
                     <?= $this->Form->control('active');?>
                 </div>

--- a/src/Template/Calendars/edit.ctp
+++ b/src/Template/Calendars/edit.ctp
@@ -50,7 +50,6 @@ foreach ($icons as $k => $v) {
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
-                    <?= $this->Form->control('source', ['label' => __('Source Name')]); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
                     <?= $this->Form->input('templates', [
@@ -67,6 +66,8 @@ foreach ($icons as $k => $v) {
                         'class' => 'select2',
                         'empty' => true
                     ]) ?>
+                </div>
+                <div class="col-xs-12 col-md-6">
                     <?= $this->Form->input('icon', [
                         'type' => 'select',
                         'options' => $icons,
@@ -74,9 +75,6 @@ foreach ($icons as $k => $v) {
                         'empty' => true
                     ]) ?>
 
-                </div>
-                <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->control('source_id', ['type' => 'text', 'label' => __('Source ID')]);?>
 
                     <?= $this->Form->control('active');?>
                 </div>

--- a/src/Template/Calendars/index.ctp
+++ b/src/Template/Calendars/index.ctp
@@ -65,20 +65,6 @@ echo $this->Html->script(
                                     <div class="col-xs-4">
                                         <div class="btn-group btn-group-xs pull-right">
                                             <?php
-                                                echo $this->Form->postLink(
-                                                    '<i class="fa fa-refresh"></i>',
-                                                    [
-                                                        'plugin' => 'Qobo/Calendar',
-                                                        'controller' => 'Calendars',
-                                                        'action' => 'synchronize',
-                                                        $calendar['id'],
-                                                    ],
-                                                    [
-                                                        'class' => 'btn btn-default',
-                                                        'escape' => false,
-                                                        'confirm' => __('Are you sure you want to synchronize calendar "{0}"?', $calendar['name']),
-                                                    ]
-                                                );
                                                 echo $this->Html->link(
                                                     '<i class="fa fa-eye"></i>',
                                                     [

--- a/src/Template/Calendars/view.ctp
+++ b/src/Template/Calendars/view.ctp
@@ -61,16 +61,10 @@
                     <?= $calendar->color; ?>
                 </div>
                 <div class="col-xs-4 col-md-2 text-right">
-                    <strong>Calendar Source ID:</strong>
-                </div>
-                <div class="col-xs-8 col-md-4">
-                    <?= $calendar->source_id; ?>
-                </div>
-                <div class="col-xs-4 col-md-2 text-right">
                     <strong>Created:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= $calendar->created; ?>
+                    <?= $calendar->created->format('Y-m-d H:i'); ?>
                 </div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong>Name:</strong>
@@ -84,19 +78,30 @@
                 <div class="col-xs-8 col-md-4">
                     <?= $calendar->icon; ?>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="box box-default">
+        <div class="box-header with-border">
+            <h3 class="box-title"><?= __('Source & Source ID Links');?></h3>
+        </div>
+        <div class="box-body">
+            <div class="row">
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong>Calendar Source ID:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= $calendar->source_id; ?>
+                </div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong>Calendar Source:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
                     <?= $calendar->source; ?>
                 </div>
-                <div class="col-xs-4 col-md-2 text-right">
-                    <strong>Modified:</strong>
-                </div>
-                <div class="col-xs-8 col-md-4">
-                    <?= $calendar->modified; ?>
-                </div>
             </div>
         </div>
     </div>
+
 </section>


### PR DESCRIPTION
Source fields would remain hidden from the user editing, to avoid breaking external integrations