### PR TITLE
Added event was shown on today's calendar date

### DIFF
--- a/src/Controller/CalendarEventsController.php
+++ b/src/Controller/CalendarEventsController.php
@@ -99,9 +99,11 @@ class CalendarEventsController extends AppController
             $entity = [
                 'id' => $saved->id,
                 'title' => $saved->title,
-                'start' => $saved->start_date,
-                'end' => $saved->end_date,
-                'color' => $calendar->color
+                'start_date' => $saved->start_date,
+                'end_date' => $saved->end_date,
+                'color' => $calendar->color,
+                'calendar_id' => $calendar->id,
+                'event_type' => $saved->event_type
             ];
 
             if ($saved) {

--- a/webroot/js/calendar.js
+++ b/webroot/js/calendar.js
@@ -130,9 +130,11 @@ var calendar = calendar || {};
                         id: resp.event.entity.id,
                         title: resp.event.entity.title,
                         start: moment().format(resp.event.entity.start_date),
-                        color: resp.event.entity.color
+                        end: moment().format(resp.event.entity.end_date),
+                        color: resp.event.entity.color,
+                        calendar_id: resp.event.entity.calendar_id,
+                        event_type: resp.event.entity.elem_type
                     };
-
                     $(that.calendarContainer).fullCalendar('addEventSource', [event]);
                 }
 


### PR DESCRIPTION
Minor inconsistencies on the response of `createEvent` method leaded to displaying added events on today's date. After refresh, an event would move to correct time slot.