### PR TITLE
Adding sync attendees script and joinTable (task #4064)

### DIFF
--- a/config/Migrations/20170629114150_AddResponseStatusToEventsAttendees.php
+++ b/config/Migrations/20170629114150_AddResponseStatusToEventsAttendees.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddResponseStatusToEventsAttendees extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('events_attendees');
+        $table->addColumn('response_status', 'string', [
+            'default' => null,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}

--- a/src/Controller/CalendarsController.php
+++ b/src/Controller/CalendarsController.php
@@ -41,9 +41,11 @@ class CalendarsController extends AppController
     public function index()
     {
         $calendars = $this->Calendars->getCalendars();
-
         $this->set(compact('calendars'));
-        $this->set('_serialize', ['calendars']);
+
+        if ($this->request->is('ajax')) {
+            $this->set('_serialize', 'calendars');
+        }
     }
 
     /**

--- a/src/Model/Table/CalendarAttendeesTable.php
+++ b/src/Model/Table/CalendarAttendeesTable.php
@@ -40,9 +40,11 @@ class CalendarAttendeesTable extends Table
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('Muffin/Trash.Trash');
 
         $this->belongsToMany('CalendarEvents', [
             'joinTable' => 'events_attendees',
+            'foreignKey' => 'calendar_attendee_id'
         ]);
     }
 

--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -50,6 +50,7 @@ class CalendarEventsTable extends Table
 
         $this->belongsToMany('CalendarAttendees', [
             'joinTable' => 'events_attendees',
+            'foreignKey' => 'calendar_event_id',
         ]);
     }
 

--- a/src/Shell/Task/SyncTask.php
+++ b/src/Shell/Task/SyncTask.php
@@ -71,10 +71,13 @@ class SyncTask extends Shell
             foreach ($calendars as $k => $calendar) {
                 $resultEvents = $table->syncCalendarEvents($calendar, $options);
 
+                $resultAttendees = $table->syncEventsAttendees($calendar, $resultEvents);
+
                 $output[] = [
                     'action' => $actionName,
                     'calendar' => $calendar,
-                    'events' => $resultEvents
+                    'events' => $resultEvents,
+                    'attendees' => $resultAttendees,
                 ];
 
                 $progress->increment(100 / ++$calendarsProcessed);


### PR DESCRIPTION
Each event allows to store a number of attendees participating in the event.
Each attendees is linked via `joinTable` (events_attendees), that also contains `response_status` field to identify who's going to participate in the event.

For now, it's a basic prototype of sync functionality, that allows to fetch attendees along with events and calendars from the external source like Google Calendar.