### PR TITLE
Adding CsvMigrations element menu and fallback items (task #4064)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "qobo/cakephp-utils": "^4.0"
+        "qobo/cakephp-utils": "^4.0",
+        "lorenzo/audit-stash": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit":"^5.0",

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -5,5 +5,15 @@ use App\Controller\AppController as BaseController;
 
 class AppController extends BaseController
 {
-
+    /**
+     * Initialize hook method
+     *
+     * Use this method to add common initialization code like loading components.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+        parent::initialize();
+    }
 }

--- a/src/Model/Table/CalendarAttendeesTable.php
+++ b/src/Model/Table/CalendarAttendeesTable.php
@@ -41,6 +41,7 @@ class CalendarAttendeesTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('Muffin/Trash.Trash');
+        $this->addBehavior('AuditStash.AuditLog');
 
         $this->belongsToMany('CalendarEvents', [
             'joinTable' => 'events_attendees',

--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -41,6 +41,7 @@ class CalendarEventsTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('Muffin/Trash.Trash');
+        $this->addBehavior('AuditStash.AuditLog');
 
         $this->belongsTo('Calendars', [
             'foreignKey' => 'calendar_id',

--- a/src/Model/Table/CalendarsTable.php
+++ b/src/Model/Table/CalendarsTable.php
@@ -45,6 +45,7 @@ class CalendarsTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('Muffin/Trash.Trash');
+        $this->addBehavior('AuditStash.AuditLog');
 
         $this->hasMany('CalendarEvents', [
             'foreignKey' => 'calendar_id',

--- a/src/Template/Calendars/view.ctp
+++ b/src/Template/Calendars/view.ctp
@@ -15,7 +15,18 @@
         <div class="col-xs-12 col-md-6">
             <div class="pull-right">
                 <div class="btn-group btn-group-sm" role="group">
-                <?php $url = [
+                <?php
+                $elementFound = $this->elementExists('CsvMigrations.Menu/view_top');
+
+                if ($elementFound) {
+                    echo $this->element('CsvMigrations.Menu/view_top', [
+                        'options' => [
+                            'entity' => $calendar,
+                            ],
+                        'displayField' => 'name',
+                    ]);
+                } else {
+                    $url = [
                         'plugin' => $this->request->plugin,
                         'controller' => $this->request->controller,
                         'action' => 'edit',
@@ -31,10 +42,10 @@
                         ),
                         'url' => $url
                     ];
-
                     foreach ($menu as $item) {
                         echo $item['html'];
                     }
+                }
                 ?>
                 </div>
             </div>


### PR DESCRIPTION
Calendar plugin used in conjunction with cakephp-csv-migrations plugin, which automatically loads CRUD buttons via `view_top.ctp` element. In case you don't use this plugin - it falls back to its own buttons when viewing a calendar record.

AuditStash plugin is used for `cakephp-csv-migrations` changelog button, thus added for compatibility reasons.