### PR TITLE
Composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "qobo/cakephp-utils": "^5.0",
-        "lorenzo/audit-stash": "^1.0",
         "rlanvin/php-rrule": "^1.5"
     },
     "require-dev": {


### PR DESCRIPTION
Removed `lorenzo/audit-stash` from composer requirements as it
is already required by `qobo/cakephp-utils`.