### PR TITLE
Disallow adding events to noneditable calendars (task #4321)

### DIFF
--- a/webroot/js/calendar.js
+++ b/webroot/js/calendar.js
@@ -796,7 +796,7 @@ var calendarApp = new Vue({
             this.calendarsList = [];
             if (this.calendars) {
                this.calendars.forEach((elem, key) => {
-                    if (elem.permissions.edit) {
+                    if (elem.permissions.edit && elem.editable != false) {
                         self.calendarsList.push( { value: elem.id, label: elem.name } );
                     }
                });


### PR DESCRIPTION
Imported calendars from Google API are currently marked as `editable = false` to avoid adding any events to them until backward sync is implemented.