### PR TITLE
Keep calendars in the DB upon sync (task #4583)

### DIFF
--- a/src/Model/Table/CalendarsTable.php
+++ b/src/Model/Table/CalendarsTable.php
@@ -10,6 +10,7 @@ use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
+use Qobo\Calendar\Model\Table\CalendarEventsTable;
 use \ArrayObject;
 
 /**
@@ -408,9 +409,11 @@ class CalendarsTable extends Table
                     $result = $table->save($entity);
                 }
 
-                if (in_array($actionName, ['delete']) && !empty($item)) {
-                    if ($table->delete($item)) {
-                        $result[] = $item;
+                if ($table instanceof CalendarEventsTable) {
+                    if (in_array($actionName, ['delete']) && !empty($item)) {
+                        if ($table->delete($item)) {
+                            $result[] = $item;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In case of Network connectivity issues, with extrernal data retrieved from the Events, we might end up in the case when some of the calendar entries aren't received. The sync script will assume they're meant for deletion.

We disabled deletion of calendar entries, so the user would do it manually.