### PR TITLE
Converting Generic Objects to calendar events (task #5394)

### DIFF
--- a/src/Controller/CalendarsController.php
+++ b/src/Controller/CalendarsController.php
@@ -102,6 +102,11 @@ class CalendarsController extends AppController
 
         if ($this->request->is('post')) {
             $data = $this->request->getData();
+
+            if (!empty($data['event_types'])) {
+                $data['event_types'] = json_encode($data['event_types']);
+            }
+
             $calendar = $this->Calendars->patchEntity($calendar, $data);
 
             if ($this->Calendars->save($calendar)) {

--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -477,7 +477,15 @@ class CalendarEventsTable extends Table
             }
 
             foreach ($calendar['event_types'] as $type => $properties) {
-                $value = 'Config::' . $calendar['name'] . '::' . $type;
+                $value = $this->getEventTypeName([
+                    'name' => $calendar['name'],
+                    'type' => $type,
+                ]);
+
+                if (empty($value)) {
+                    continue;
+                }
+
                 $result[$value] = $value;
             }
         }
@@ -493,6 +501,29 @@ class CalendarEventsTable extends Table
         asort($result);
 
         return $result;
+    }
+
+    /**
+     * Get Event Type name
+     *
+     * @param array $data with name parts
+     * @param array $options for extra settings if needed
+     *
+     * @return string $name containing event type definition.
+     */
+    public function getEventTypeName(array $data = [], array $options = [])
+    {
+        if (empty($data['name'])) {
+            return;
+        }
+
+        $prefix = !empty($options['prefix']) ? $options['prefix'] : 'Config';
+        $type = !empty($options['type']) ? $options['type'] : 'default';
+        $delimiter = '::';
+
+        $name = $prefix . $delimiter . $data['name'] . $delimiter . $type;
+
+        return $name;
     }
 
     /**
@@ -731,8 +762,9 @@ class CalendarEventsTable extends Table
         foreach ($calendars as $calendar) {
             $options = array_merge($options->getArrayCopy(), ['calendar' => $calendar]);
             $options = new ArrayObject($options);
-
+            $entity = $options['entity'];
             $eventObject = $table->getObjectInstance($entity, $map, $options);
+
             $calendarEntity = $eventObject->toEntity();
 
             if (!$calendarEntity) {

--- a/src/Object/Objects/AbstractObject.php
+++ b/src/Object/Objects/AbstractObject.php
@@ -99,10 +99,6 @@ abstract class AbstractObject implements ObjectInterface
 
         $entity = new $entityProvider($data);
 
-        foreach ($data as $property => $value) {
-            //$entity->setDirty($property, false);
-        }
-
         return $entity;
     }
 }

--- a/src/Template/Calendars/view.ctp
+++ b/src/Template/Calendars/view.ctp
@@ -13,6 +13,7 @@
 /**
  * @var \App\View\AppView $this
  */
+
 ?>
 <section class="content-header">
     <div class="row">
@@ -32,6 +33,7 @@
                 if ($elementFound) {
                     echo $this->element('CsvMigrations.Menu/view_top', [
                         'user' => $user,
+                        'entity' => $calendar,
                         'options' => [
                             'entity' => $calendar,
                             ],


### PR DESCRIPTION
- Tested and fixed custom generic objects saving using an example of transforming user birthdates into calendar events.
- Events are stored based on the `event_types` saved inside calendar db record.