### PR TITLE
Keep currently click date on modals (Task #6034)

### DIFF
--- a/resources/src/components/Calendar.vue
+++ b/resources/src/components/Calendar.vue
@@ -12,7 +12,7 @@
       @modal-toggle="toggleModal">
         <template slot="header-title">{{ modal.title }}</template>
         <template slot="body-content">
-          <event-create v-if="modal.type === 'create'"></event-create>
+          <event-create v-if="modal.type === 'create'" :current-moment="currentMoment"></event-create>
           <event-view v-if="modal.type === 'view'" :event-info="eventInfo"></event-view>
         </template>
     </modal>
@@ -45,6 +45,7 @@ export default {
         title: null,
         type: null
       },
+      currentMoment: null,
       calendar: null,
       eventInfo: null,
       format: 'YYYY-MM-DD',
@@ -149,6 +150,9 @@ export default {
         showFooter: true,
         type: 'create'
       })
+      this.currentMoment = moment
+      this.$store.commit('event/setStart', moment.format('YYYY-MM-DD HH:mm'))
+      this.$store.commit('event/setEnd', moment.format('YYYY-MM-DD HH:mm'))
     },
     openEvent (event) {
       const self = this

--- a/resources/src/components/modals/EventCreate.vue
+++ b/resources/src/components/modals/EventCreate.vue
@@ -31,11 +31,23 @@
 
     <div class="row">
       <div class="col-xs-12 col-md-6">
-        <datepicker label="Start" name="start" format="YYYY-MM-DD HH:mm" event-click="" @date-changed="updateStart"></datepicker>
+        <datepicker
+          label="Start"
+          name="start"
+          config-field="start_date"
+          :event-click="currentMoment"
+          @date-changed="updateStart">
+        </datepicker>
       </div>
 
       <div class="col-xs-12 col-md-6">
-        <datepicker label="End" name="end" format="YYYY-MM-DD HH:mm" event-click="" @date-changed="updateEnd"></datepicker>
+        <datepicker
+          label="End"
+          name="end"
+          config-field="end_date"
+          :event-click="currentMoment"
+          @date-changed="updateEnd">
+        </datepicker>
       </div>
     </div>
 
@@ -92,6 +104,7 @@ import Datepicker from '@/components/ui/Datepicker.vue'
 import RecurrenceInput from '@/components/ui/RecurrenceInput.vue'
 
 export default {
+  props: ['currentMoment'],
   components: {
     RecurrenceInput,
     Datepicker,

--- a/resources/src/components/ui/Datepicker.vue
+++ b/resources/src/components/ui/Datepicker.vue
@@ -34,7 +34,7 @@ export default {
         timePicker24Hour: true,
         timePickerIncrement: 5,
         locale: {
-          format: 'YYYY-MM-dd HH:mm'
+          format: 'YYYY-MM-DD HH:mm'
         }
       }
     }
@@ -47,6 +47,14 @@ export default {
   mounted () {
     const self = this
     self.instance = $(self.$el).find('input').daterangepicker(this.options).data('daterangepicker')
+
+    if (this.eventClick) {
+      self.instance.setStartDate(this.eventClick.format(this.options.locale.format))
+      self.instance.setEndDate(this.eventClick.format(this.options.locale.format))
+      self.momentObject = this.eventClick
+      self.value = this.momentObject.format(this.options.locale.format)
+    }
+
     /* following handler used when you choose the date from popup picker */
     $(self.$el).find('input').on('apply.daterangepicker', function (ev, picker) {
       self.momentObject = moment(picker.startDate)
@@ -76,9 +84,9 @@ export default {
         }
       }
     },
+    /* @NOTE: not sure it this one is neeeded right now */
     eventClick: function () {
       let currentDate = this.instance.startDate
-
       currentDate.set('year', this.eventClick.year())
       currentDate.set('month', this.eventClick.month())
       currentDate.set('date', this.eventClick.date())

--- a/resources/src/store/modules/calendars/index.js
+++ b/resources/src/store/modules/calendars/index.js
@@ -1,7 +1,7 @@
 import ApiService from '@/common/ApiService'
 import events from '@/store/modules/events'
 
-const state = {
+const initialState = {
   data: [],
   activeIds: [],
   options: {
@@ -13,6 +13,8 @@ const state = {
     printable: false
   }
 }
+
+export const state = Object.assign({}, initialState)
 
 const mutations = {
   setDataItems (state, payload) {

--- a/resources/src/store/modules/events/index.js
+++ b/resources/src/store/modules/events/index.js
@@ -1,11 +1,13 @@
 import ApiService from '@/common/ApiService'
 
-const state = {
+const initialState = {
   data: [],
   options: {
     background: false,
   }
 }
+
+export const state = Object.assign({}, initialState)
 
 const mutations = {
   setOptions (state, payload) {

--- a/resources/src/store/modules/user/index.js
+++ b/resources/src/store/modules/user/index.js
@@ -1,6 +1,8 @@
 import ApiService from '@/common/ApiService'
 
-const state = {}
+const initialState = {}
+
+export const state  = Object.assign({}, initialState)
 
 const mutations = {}
 


### PR DESCRIPTION
- Keeping current date `moment` clicked on the calendar
- Allow store modules to have `initialState` for later reset functionality