### PR TITLE
SQLite errors in unit tests for infinite events(task #5394)

### DIFF
--- a/src/Event/Plugin/GetCalendarsListener.php
+++ b/src/Event/Plugin/GetCalendarsListener.php
@@ -172,7 +172,7 @@ class GetCalendarsListener implements EventListenerInterface
     {
         $table = TableRegistry::get('Qobo/Calendar.CalendarEvents');
 
-        $events = $table->getCalendarEvents($calendar, $options);
+        $events = $table->getEvents($calendar, $options);
 
         $event->result = $events;
     }

--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -183,7 +183,7 @@ class CalendarEventsTable extends Table
      *
      * @param \Cake\ORM\Table $calendar record
      * @param array $options with filter params
-     * @param boolean $isInfinite flag to find inifinite events like birthdays
+     * @param bool $isInfinite flag to find inifinite events like birthdays
      *
      * @return array $result of events (minimal structure)
      */
@@ -263,7 +263,7 @@ class CalendarEventsTable extends Table
      *
      * @param array $events from findCalendarEvents
      * @param array $options containing month viewport (end/start interval).
-     * @param boolean $isInfinite flag for infinite events like birthdays
+     * @param bool $isInfinite flag for infinite events like birthdays
      *
      * @return array $result containing event records
      */

--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -186,38 +186,6 @@ class CalendarEventsTable extends Table
      *
      * @return array $result of events (minimal structure)
      */
-    public function getCalendarEvents($calendar, $options = [])
-    {
-        $result = [];
-
-        if (!$calendar) {
-            return $result;
-        }
-
-        $options = array_merge($options, ['calendar_id' => $calendar->id]);
-        $resultSet = $this->findCalendarEvents($options);
-
-        if (empty($resultSet)) {
-            return $result;
-        }
-
-        foreach ($resultSet as $event) {
-            $eventItem = $this->prepareEventData($event, $calendar);
-
-            array_push($result, $eventItem);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Get Events of specific calendar
-     *
-     * @param \Cake\ORM\Table $calendar record
-     * @param array $options with filter params
-     *
-     * @return array $result of events (minimal structure)
-     */
     public function getEvents($calendar, $options = [])
     {
         $result = [];

--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -183,10 +183,11 @@ class CalendarEventsTable extends Table
      *
      * @param \Cake\ORM\Table $calendar record
      * @param array $options with filter params
+     * @param boolean $isInfinite flag to find inifinite events like birthdays
      *
      * @return array $result of events (minimal structure)
      */
-    public function getEvents($calendar, $options = [])
+    public function getEvents($calendar, $options = [], $isInfinite = true)
     {
         $result = [];
 
@@ -196,7 +197,7 @@ class CalendarEventsTable extends Table
 
         $events = $this->findCalendarEvents($options);
 
-        $infiniteEvents = $this->getInfiniteEvents($events, $options);
+        $infiniteEvents = $this->getInfiniteEvents($events, $options, $isInfinite);
         $events = array_merge($events, $infiniteEvents);
 
         if (empty($events)) {
@@ -262,13 +263,14 @@ class CalendarEventsTable extends Table
      *
      * @param array $events from findCalendarEvents
      * @param array $options containing month viewport (end/start interval).
+     * @param boolean $isInfinite flag for infinite events like birthdays
      *
      * @return array $result containing event records
      */
-    public function getInfiniteEvents($events, $options = [])
+    public function getInfiniteEvents($events, $options = [], $isInfinite = true)
     {
         $result = $existingEventIds = [];
-        $query = $this->findCalendarEvents($options, true);
+        $query = $this->findCalendarEvents($options, $isInfinite);
 
         if (!$query) {
             return $result;
@@ -554,7 +556,6 @@ class CalendarEventsTable extends Table
     protected function findCalendarEvents($options = [], $isInfinite = false)
     {
         $conditions = [];
-
         if ($isInfinite) {
             $range = $this->getEventRange($options);
             $conditions['is_recurring'] = true;

--- a/tests/TestCase/Model/Table/CalendarEventsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarEventsTableTest.php
@@ -62,14 +62,25 @@ class CalendarEventsTableTest extends TestCase
     {
         $result = $this->CalendarEvents->getEvents(null);
         $this->assertEquals($result, []);
-
-        $this->Calendars = TableRegistry::get('Qobo/Calendar.Calendars');
         $dbItems = $this->Calendars->getCalendars();
         $options = [
             'calendar_id' => $dbItems[0]->id,
         ];
+        $result = $this->CalendarEvents->getEvents($dbItems[0], $options, false);
+        $this->assertNotEmpty($result);
+    }
 
-        $result = $this->CalendarEvents->getEvents($dbItems[0], $options);
+    public function testGetEventsWithTimePeriod()
+    {
+        $options = [
+            'calendar_id' => '00000000-0000-0000-0000-000000000001',
+            'period' => [
+                'start_date' => '2017-08-10 09:00:00',
+                'end_date' => '2017-08-12 09:00:00'
+            ],
+        ];
+        $calendar = $this->Calendars->get($options['calendar_id']);
+        $result = $this->CalendarEvents->getEvents($calendar, $options, false);
         $this->assertNotEmpty($result);
     }
 
@@ -78,8 +89,7 @@ class CalendarEventsTableTest extends TestCase
      */
     public function testSetEventTitle($data, $expected)
     {
-        $calendars = TableRegistry::get('Qobo/Calendar.Calendars');
-        $dbItems = $calendars->getCalendars();
+        $dbItems = $this->Calendars->getCalendars();
 
         $title = $this->CalendarEvents->setEventTitle($data, $dbItems[0]);
         $this->assertEquals($title, $expected);

--- a/tests/TestCase/Model/Table/CalendarEventsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarEventsTableTest.php
@@ -73,56 +73,6 @@ class CalendarEventsTableTest extends TestCase
         $this->assertNotEmpty($result);
     }
 
-    public function testGetEventsNoEvents()
-    {
-        $result = $this->CalendarEvents->getEvents(null);
-        $this->assertEquals($result, []);
-
-        $this->Calendars = TableRegistry::get('Qobo/Calendar.Calendars');
-        $dbItems = $this->Calendars->getCalendars([
-            'conditions' => [
-                'id' => '00000000-0000-0000-0000-000000000004',
-            ]
-        ]);
-
-        $options = [
-            'calendar_id' => '00000000-0000-0000-0000-000000000004',
-        ];
-
-        $result = $this->CalendarEvents->getCalendarEvents($dbItems[0], $options);
-        $this->assertEmpty($result);
-    }
-
-    public function testGetCalendarEvents()
-    {
-        $calendars = TableRegistry::get('Qobo/Calendar.Calendars');
-        $dbItems = $calendars->getCalendars();
-
-        $result = $this->CalendarEvents->getCalendarEvents($dbItems[0]);
-        $this->assertTrue(is_array($result));
-        $this->assertNotEmpty($result);
-    }
-
-    public function testGetCalendarEventsWithPeriod()
-    {
-        $calendars = TableRegistry::get('Qobo/Calendar.Calendars');
-        $dbItems = $calendars->getCalendars();
-
-        $result = $this->CalendarEvents->getCalendarEvents($dbItems[0], [
-            'period' => [
-                'start_date' => '2017-06-16 09:00:00',
-                'end_date' => '2017-06-16 20:00:00',
-            ],
-        ]);
-
-        $this->assertNotEmpty($result);
-        $this->assertTrue(is_array($result));
-
-        $result = $this->CalendarEvents->getCalendarEvents(null);
-        $this->assertEquals($result, []);
-        $this->assertTrue(is_array($result));
-    }
-
     /**
      * @dataProvider testEventTitleProvider
      */


### PR DESCRIPTION
- Adding more control on the result set being fetched. Avoid infinite events (like birthdays) on demand.