### PR TITLE
Improving Calendar code (task #5394)

### DIFF
--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -818,12 +818,6 @@ class CalendarEventsTable extends Table
         $result['CalendarEvents'] = $data;
         if (!empty($data['recurrence'])) {
             $recurrence = $this->setRRuleConfiguration($data['recurrence']);
-            $intervals = $this->getRecurrence($data['recurrence'], [
-                'start' => $data['start_date'],
-                'end' => $data['end_date'],
-                'limit' => 1
-            ]);
-            $result['CalendarEvents']['end_date'] = $intervals[0]['end'];
             $result['CalendarEvents']['is_recurring'] = true;
             $result['CalendarEvents']['recurrence'] = $recurrence;
         }

--- a/tests/Fixture/CalendarEventsFixture.php
+++ b/tests/Fixture/CalendarEventsFixture.php
@@ -68,7 +68,7 @@ class CalendarEventsFixture extends TestFixture
             'trashed' => null,
             'event_type' => 'Lorem ipsum dolor sit amet',
             'is_recurring' => 0,
-            'recurrence' => '',
+            'recurrence' => null,
         ],
         [
             'id' => '00000000-0000-0000-0000-000000000002',
@@ -100,7 +100,7 @@ class CalendarEventsFixture extends TestFixture
             'trashed' => null,
             'event_type' => 'default_event',
             'is_recurring' => 1,
-            'recurrence' => '["RRULE:FREQ=YEARLY;COUNT=5"]',
+            'recurrence' => 'RRULE:FREQ=YEARLY;COUNT=5',
         ],
         [
             'id' => '00000000-0000-0000-0000-000000000004',
@@ -116,7 +116,7 @@ class CalendarEventsFixture extends TestFixture
             'trashed' => null,
             'event_type' => 'special_event',
             'is_recurring' => 1,
-            'recurrence' => '',
+            'recurrence' => null,
         ],
         [
             'id' => '00000000-0000-0000-0000-000000000005',
@@ -132,7 +132,7 @@ class CalendarEventsFixture extends TestFixture
             'trashed' => null,
             'event_type' => 'special_event',
             'is_recurring' => 1,
-            'recurrence' => '["RRULE:FREQ=MONTHLY;COUNT=2"]',
+            'recurrence' => 'RRULE:FREQ=MONTHLY;COUNT=2',
         ],
     ];
 }

--- a/tests/TestCase/Controller/CalendarEventsControllerTest.php
+++ b/tests/TestCase/Controller/CalendarEventsControllerTest.php
@@ -159,7 +159,7 @@ class CalendarEventsControllerTest extends IntegrationTestCase
             'start_date' => '2018-04-09 09:00:00',
             'end_date' => '2018-04-09 10:00:00',
             'is_recurring' => true,
-            'recurrence' => '["RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5"]',
+            'recurrence' => 'RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5',
             'attendees_ids' => [
                '00000000-0000-0000-0000-000000000001'
             ]

--- a/tests/TestCase/Model/Table/CalendarEventsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarEventsTableTest.php
@@ -82,6 +82,9 @@ class CalendarEventsTableTest extends TestCase
         $calendar = $this->Calendars->get($options['calendar_id']);
         $result = $this->CalendarEvents->getEvents($calendar, $options, false);
         $this->assertNotEmpty($result);
+
+        $result = $this->CalendarEvents->getEvents($calendar, [], false);
+        $this->assertEquals($result, []);
     }
 
     /**
@@ -115,26 +118,6 @@ class CalendarEventsTableTest extends TestCase
                 ],
                 'Calendar - 1 - Foobar',
             ]
-        ];
-    }
-
-    /**
-     * @dataProvider testGetRRuleConfigurationProvider
-     * @exp
-     */
-    public function testGetRRuleConfguration($data, $expected, $msg)
-    {
-        $result = $this->CalendarEvents->getRRuleConfiguration($data);
-
-        $this->assertEquals($result, $expected, $msg);
-    }
-
-    public function testGetRRuleConfigurationProvider()
-    {
-        return [
-            [ ['foo' => 'bar'], '', 'RRule wasnt found'],
-            [ [], '', 'Empty array' ],
-            [ ['RRULE:FREQ=YEARLY'], 'RRULE:FREQ=YEARLY', 'Couldnt fetch correct RRULE element for array' ],
         ];
     }
 
@@ -201,6 +184,32 @@ class CalendarEventsTableTest extends TestCase
         $result = $this->CalendarEvents->getEventTypes(['calendar' => $calendar, 'user' => null]);
         $this->assertNotEmpty($result);
         $this->assertTrue(is_array($result));
+    }
+
+    public function testSetRRuleConfiguration()
+    {
+        $data = 'FREQ=MONTHLY;COUNT=30;WKST=MO';
+        $recurrence = $this->CalendarEvents->setRRuleConfiguration($data);
+        $this->assertEquals($recurrence, 'RRULE:' . $data);
+    }
+
+    /**
+     * @dataProvider testGetRRuleConfigurationProvider
+     */
+    public function testGetRRuleConfiguration($data, $expected)
+    {
+        $result = $this->CalendarEvents->getRRuleConfiguration($data);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetRRuleConfigurationProvider()
+    {
+        return [
+            ['FREQ=DAILY;COUNT=5', 'RRULE:FREQ=DAILY;COUNT=5'],
+            ['RRULE:FREQ=MONTHLY;COUNT=1', 'RRULE:FREQ=MONTHLY;COUNT=1'],
+            ['', null],
+            [null, null],
+        ];
     }
 
     /**


### PR DESCRIPTION
- Fixed infinite recurring events like birthdays
- Placing `recurrence` as a string, without json encoding that created confusion.