### PR TITLE
Adding Default config event types for all calendars (task #5394)

### DIFF
--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -334,6 +334,52 @@ class CalendarEventsTable extends Table
     }
 
     /**
+     * Get Event Types from Configure::read()
+     *
+     * @param string $name of the event type
+     *
+     * @return array $result containing key/value pair of event types.
+     */
+    public function getEventTypeBy($name = null)
+    {
+        $result = [];
+        $configs = Configure::read('Calendar.Types');
+
+        if (empty($configs)) {
+            return $result;
+        }
+
+        if (!empty($name)) {
+            $configs = array_filter($configs, function ($item) use ($name) {
+                if ($name == $item['value']) {
+                    return $item;
+                }
+            });
+        }
+
+        $configs = array_values($configs);
+
+        foreach ($configs as $k => $calendar) {
+            if (empty($calendar['calendar_events'])) {
+                continue;
+            }
+
+            foreach ($calendar['calendar_events'] as $type => $properties) {
+                $value = $this->getEventTypeName([
+                    'name' => $calendar['name'],
+                    'type' => $type,
+                ]);
+
+                $result[$value] = $value;
+            }
+        }
+
+        asort($result);
+
+        return $result;
+    }
+
+    /**
      * Get Event types for the calendar event
      *
      * @param array $options of the data including user
@@ -364,24 +410,8 @@ class CalendarEventsTable extends Table
             $result = array_merge($result, $event->result);
         }
 
-        $configs = Configure::read('Calendar.Types');
-
-        foreach ($configs as $calendar) {
-            if (empty($calendar['calendar_events'])) {
-                continue;
-            }
-
-            foreach ($calendar['calendar_events'] as $type => $properties) {
-                $value = $this->getEventTypeName([
-                    'name' => $calendar['name'],
-                    'type' => $type,
-                ]);
-
-                $result[$value] = $value;
-            }
-        }
-
-        asort($result);
+        $configEventTypes = $this->getEventTypeBy();
+        $result = array_merge($result, $configEventTypes);
 
         return $result;
     }

--- a/src/Model/Table/CalendarsTable.php
+++ b/src/Model/Table/CalendarsTable.php
@@ -124,6 +124,21 @@ class CalendarsTable extends Table
         if (empty($entity->color)) {
             $entity->color = $this->getColor($entity);
         }
+
+        $this->CalendarEvents = TableRegistry::get('Qobo/Calendar.CalendarEvents');
+        $default = $this->CalendarEvents->getEventTypeBy('default');
+        $defaultKey = key($default);
+        if (!empty($entity->event_types)) {
+            $types = json_decode($entity->event_types, true);
+
+            if (!in_array($defaultKey, $types)) {
+                array_push($types, $defaultKey);
+                asort($types);
+                $entity->event_types = json_encode($types);
+            }
+        } else {
+            $entity->event_types = json_encode([$defaultKey]);
+        }
     }
 
     /**

--- a/tests/TestCase/Controller/CalendarsControllerTest.php
+++ b/tests/TestCase/Controller/CalendarsControllerTest.php
@@ -128,8 +128,8 @@ class CalendarsControllerTest extends IntegrationTestCase
         $data = [
             'icon' => 'facebook',
             'event_types' => [
-                'Foo::bar::default',
                 'Bar::foo::default',
+                'Foo::bar::default',
             ]
         ];
 
@@ -140,7 +140,7 @@ class CalendarsControllerTest extends IntegrationTestCase
 
         $this->assertEquals($edited->icon, $data['icon']);
         $this->assertEquals($calendarId, $edited->id);
-        $this->assertEquals(json_decode($edited->event_types, true), $data['event_types']);
+        $this->assertTrue(in_array('Config::Default::Default', json_decode($edited->event_types, true)));
     }
 
     public function testDeleteResponseOk()

--- a/tests/TestCase/Model/Table/CalendarEventsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarEventsTableTest.php
@@ -202,6 +202,12 @@ class CalendarEventsTableTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testGetDefaultEventType()
+    {
+        $result = $this->CalendarEvents->getEventTypeBy('default');
+        $this->assertNotEmpty($result);
+    }
+
     public function testGetRRuleConfigurationProvider()
     {
         return [


### PR DESCRIPTION
User won't be able to save an event without its type,
so by default we pass default event type from `config/calendar.php`
setup.