### PR TITLE
Better fetching of recurring events (task #7500)

### DIFF
--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -24,7 +24,6 @@ use Cake\Validation\Validator;
 use \ArrayObject;
 use \RRule\RRule;
 
-
 /**
  * CalendarEvents Model
  *

--- a/src/Shell/Task/SyncTask.php
+++ b/src/Shell/Task/SyncTask.php
@@ -82,7 +82,6 @@ class SyncTask extends Shell
         if (!empty($this->params['end'])) {
             $options['period']['end_date'] = $this->params['end'];
         }
-
         $result['calendars'] = $table->syncCalendars($options);
 
         if (empty($result['calendars'])) {
@@ -238,17 +237,20 @@ class SyncTask extends Shell
                 $entity->content = sprintf("%s %s", $user->first_name, $user->last_name);
                 $entity->is_recurring = true;
                 $entity->is_allday = true;
-
-                $entity->start_date = date('Y-m-d 09:00:00', strtotime($user->birthdate));
-                $entity->end_date = date('Y-m-d 18:00:00', strtotime($user->birthdate));
+                $entity->start_date = date('Y-m-d 09:00:00', strtotime($user->birthdate->format('Y-m-d')));
+                $entity->end_date = date('Y-m-d 18:00:00', strtotime($user->birthdate->format('Y-m-d')));
                 $entity->recurrence = json_encode(['RRULE:FREQ=YEARLY']);
                 $birthdayEvent = $eventsTable->save($entity);
 
                 $result['added'][] = $birthdayEvent;
             } else {
+                // @NOTE: patching user birthdays in case mistake was done
+                // via user profiles.
                 $entity = $eventsTable->patchEntity($birthdayEvent, [
                     'title' => sprintf("%s %s", $user->first_name, $user->last_name),
                     'is_allday' => true,
+                    'start_date' => date('Y-m-d 09:00:00', strtotime($user->birthdate->format('Y-m-d'))),
+                    'end_date' => date('Y-m-d 18:00:00', strtotime($user->birthdate->format('Y-m-d'))),
                 ]);
 
                 $birthdayEvent = $eventsTable->save($entity);


### PR DESCRIPTION
SQL conditions using month limits `MONTH(start_date) > =` and `MONTH(end_date) <= ` limits the users UI to display only recurring events that've been created with the viewable port intervals.

*Note: when you're viewing monthly calendar you have previous-current-next month events being shown.*

using `MONTH(start_date) IN()` statement allows use to fetch all recurring events within these 3 months, that will avoid loosing January (i.e.` 11 < x < 01` logical nonsense).

Also, we remove `YEAR(start_date) >=` limitation to load recurring events previously created. That will allow use to list back/forth and load recurring events as well.