### PR TITLE
Removing unused use namespaces

### DIFF
--- a/src/Controller/CalendarAttendeesController.php
+++ b/src/Controller/CalendarAttendeesController.php
@@ -12,8 +12,6 @@
 namespace Qobo\Calendar\Controller;
 
 use Cake\Http\Response;
-use Cake\ORM\TableRegistry;
-use Qobo\Calendar\Controller\AppController;
 
 /**
  * CalendarAttendees Controller

--- a/src/Controller/CalendarEventsController.php
+++ b/src/Controller/CalendarEventsController.php
@@ -11,16 +11,10 @@
  */
 namespace Qobo\Calendar\Controller;
 
-use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Event\EventManager;
-use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Inflector;
 use Exception;
-use Qobo\Calendar\Controller\AppController;
 use Qobo\Calendar\Object\ObjectFactory;
-use RRule\RRule;
 
 /**
  * CalendarEvents Controller

--- a/src/Controller/CalendarsController.php
+++ b/src/Controller/CalendarsController.php
@@ -12,11 +12,8 @@
 namespace Qobo\Calendar\Controller;
 
 use Cake\Event\Event;
-use Cake\Event\EventManager;
 use Cake\ORM\TableRegistry;
-use Qobo\Calendar\Controller\AppController;
 use Qobo\Calendar\Event\EventName;
-use Qobo\Utils\Utility;
 
 /**
  * Calendars Controller

--- a/src/Event/Plugin/GetCalendarsListener.php
+++ b/src/Event/Plugin/GetCalendarsListener.php
@@ -12,18 +12,14 @@
 namespace Qobo\Calendar\Event\Plugin;
 
 use ArrayObject;
-use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
-use Cake\Network\Request;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\View\View;
 use Qobo\Calendar\Event\EventName;
-use Qobo\Calendar\Object\ObjectFactory;
-use Qobo\Calendar\Object\Objects\ObjectInterface;
 
 class GetCalendarsListener implements EventListenerInterface
 {

--- a/src/Model/Table/CalendarEventsTable.php
+++ b/src/Model/Table/CalendarEventsTable.php
@@ -17,7 +17,6 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\I18n\Time;
-use Cake\ORM\ResultSet;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;

--- a/src/Model/Table/CalendarsTable.php
+++ b/src/Model/Table/CalendarsTable.php
@@ -19,7 +19,6 @@ use Cake\Event\EventManager;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 use Qobo\Calendar\Event\EventName;
 

--- a/src/Model/Table/EventsAttendeesTable.php
+++ b/src/Model/Table/EventsAttendeesTable.php
@@ -1,8 +1,6 @@
 <?php
 namespace Qobo\Calendar\Model\Table;
 
-use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
 


### PR DESCRIPTION
Cleaned up codebase with `php-cs-fixer` from unused `use` statements.