### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,6 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-	"repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-        }
-    ],
     "require": {
         "qobo/cakephp-utils": "^13.0"
     },
@@ -59,6 +53,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/tests/TestCase/Controller/CalendarAttendeesControllerTest.php
+++ b/tests/TestCase/Controller/CalendarAttendeesControllerTest.php
@@ -16,11 +16,11 @@ class CalendarAttendeesControllerTest extends JsonIntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/calendar.users',
-        'plugin.qobo/calendar.calendar_attendees',
-        'plugin.qobo/calendar.calendar_events',
-        'plugin.qobo/calendar.events_attendees',
-        'plugin.qobo/calendar.calendars',
+        'plugin.Qobo/Calendar.Users',
+        'plugin.Qobo/Calendar.CalendarAttendees',
+        'plugin.Qobo/Calendar.CalendarEvents',
+        'plugin.Qobo/Calendar.EventsAttendees',
+        'plugin.Qobo/Calendar.Calendars',
     ];
 
     /** @var \Qobo\Calendar\Model\Table\CalendarAttendeesTable */

--- a/tests/TestCase/Controller/CalendarEventsControllerTest.php
+++ b/tests/TestCase/Controller/CalendarEventsControllerTest.php
@@ -22,11 +22,11 @@ class CalendarEventsControllerTest extends JsonIntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/calendar.users',
-        'plugin.qobo/calendar.calendar_events',
-        'plugin.qobo/calendar.events_attendees',
-        'plugin.qobo/calendar.calendar_attendees',
-        'plugin.qobo/calendar.calendars',
+        'plugin.Qobo/Calendar.Users',
+        'plugin.Qobo/Calendar.CalendarEvents',
+        'plugin.Qobo/Calendar.EventsAttendees',
+        'plugin.Qobo/Calendar.CalendarAttendees',
+        'plugin.Qobo/Calendar.Calendars',
     ];
 
     public function setUp()

--- a/tests/TestCase/Controller/CalendarsControllerTest.php
+++ b/tests/TestCase/Controller/CalendarsControllerTest.php
@@ -19,8 +19,8 @@ class CalendarsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/calendar.users',
-        'plugin.qobo/calendar.calendars',
+        'plugin.Qobo/Calendar.Users',
+        'plugin.Qobo/Calendar.Calendars',
     ];
 
     public function setUp()

--- a/tests/TestCase/Model/Table/CalendarEventsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarEventsTableTest.php
@@ -33,10 +33,10 @@ class CalendarEventsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/calendar.calendar_events',
-        'plugin.qobo/calendar.calendars',
-        'plugin.qobo/calendar.calendar_attendees',
-        'plugin.qobo/calendar.events_attendees',
+        'plugin.Qobo/Calendar.CalendarEvents',
+        'plugin.Qobo/Calendar.Calendars',
+        'plugin.Qobo/Calendar.CalendarAttendees',
+        'plugin.Qobo/Calendar.EventsAttendees',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/CalendarsTableTest.php
+++ b/tests/TestCase/Model/Table/CalendarsTableTest.php
@@ -28,8 +28,8 @@ class CalendarsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/calendar.calendars',
-        'plugin.qobo/calendar.calendar_events',
+        'plugin.Qobo/Calendar.Calendars',
+        'plugin.Qobo/Calendar.CalendarEvents',
     ];
 
     /**

--- a/tests/TestCase/Object/ObjectFactoryTest.php
+++ b/tests/TestCase/Object/ObjectFactoryTest.php
@@ -10,7 +10,7 @@ class ObjectFactoryTest extends TestCase
     protected $calendarsTable;
 
     public $fixtures = [
-        'plugin.qobo/calendar.calendars',
+        'plugin.Qobo/Calendar.Calendars',
     ];
 
     public function setUp()

--- a/tests/TestCase/Object/Objects/AttendeeTest.php
+++ b/tests/TestCase/Object/Objects/AttendeeTest.php
@@ -11,7 +11,7 @@ class AttendeeTest extends TestCase
     protected $table;
 
     public $fixtures = [
-        'plugin.qobo/calendar.calendar_attendees',
+        'plugin.Qobo/Calendar.CalendarAttendees',
     ];
 
     public function setUp()

--- a/tests/TestCase/Object/Objects/CalendarTest.php
+++ b/tests/TestCase/Object/Objects/CalendarTest.php
@@ -8,7 +8,7 @@ use Qobo\Calendar\Object\Objects\Calendar;
 class CalendarTest extends TestCase
 {
     public $fixtures = [
-        'plugin.qobo/calendar.calendars',
+        'plugin.Qobo/Calendar.Calendars',
     ];
 
     public function setUp()

--- a/tests/TestCase/Object/Objects/EventTest.php
+++ b/tests/TestCase/Object/Objects/EventTest.php
@@ -11,7 +11,7 @@ class EventTest extends TestCase
     protected $table;
 
     public $fixtures = [
-        'plugin.qobo/calendar.calendar_events',
+        'plugin.Qobo/Calendar.CalendarEvents',
     ];
 
     public function setUp()


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

