### PR TITLE
Fix column names

### DIFF
--- a/config/Migrations/20170804103542_AddIndexesToCalendars.php
+++ b/config/Migrations/20170804103542_AddIndexesToCalendars.php
@@ -13,8 +13,8 @@ class AddIndexesToCalendars extends AbstractMigration
     public function change()
     {
         $table = $this->table('calendars');
-        $table->addIndex(['source']);
-        $table->addIndex(['source_id']);
+        $table->addIndex(['calendar_source']);
+        $table->addIndex(['calendar_source_id']);
         $table->update();
     }
 }


### PR DESCRIPTION
Rename the columns used in calendars indices. This was failing in silence with past versions of Phinx.